### PR TITLE
Change selector type.

### DIFF
--- a/suricata.sublime-syntax
+++ b/suricata.sublime-syntax
@@ -3,7 +3,7 @@
 # See http://www.sublimetext.com/docs/3/syntax.html
 file_extensions:
   - rules
-scope: text.suricata
+scope: source.suricata
 contexts:
   main:
     - match: '"'


### PR DESCRIPTION
By using `source.suricata` instead `text.suricata` it is possible to
use the selector to get automatic autocompletion of keywords in
signatures using the LSP package and the [Suricata Language Server](https://github.com/StamusNetworks/suricata-language-server#sublime-text-3).