### PR TITLE
additional validation for some keywords

### DIFF
--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -29,7 +29,7 @@ contexts:
       scope: rule.error.suricata
 
     # Error - Missing semi-colon on no option payload keywords
-    - match: '(?:nocase|startswith|endswith|fast_pattern(?:only|:[0-9]+,[0-9]+)?)(?!;)'
+    - match: '(?:nocase|startswith|endswith|fast_pattern)(?!;)'
       scope: rule.error.suricata
 
     # Error - Missing semi-colon on transformations

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -36,6 +36,12 @@ contexts:
     - match: '\b(?:dotprefix|strip_whitespace|compress_whitespace|to_(md5|sha1|sha256)|pcrexform|url_decode|xor)(?!;)\b'
       scope: rule.error.suricata
 
+    # Error - Missing options or semi-colon payload keywords that accept option
+    # Support [a-zA-Z0-9\-_] for byte_extract variable names
+    # This also catches unrequired spaces
+    - match: '\b(depth|offset|distance|within)(?!:!?([0-9]+|[a-zA-Z\-_]+);)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -20,6 +20,10 @@ contexts:
     - match: 'reference:md5,([A-Fa-f0-9]{,31}|[A-Fa-f0-9]{33,});'
       scope: rule.error.suricata
 
+    # Error - Missing semi-colon at the end of a content
+    - match: 'content:\"[^\"]+\"(?!;)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -49,6 +49,13 @@ contexts:
     - match: '\b[bd]size(?!:!?(?:[0-9]+|[a-zA-Z0-9\-_]+)?(?:<|>|[<>]=|<>)?(?:[0-9]+|[a-zA-Z0-9\-_]+);)'
       scope: rule.error.suricata
 
+    # Error - Missing options or semi-colon on isdataat
+    # Support for optional ,relative
+    # Support [a-zA-Z0-9\-_] for byte_extract variable names
+    # This also catches unrequired spaces
+    - match: '\bisdataat(?!:!?(?:[0-9]+|[a-zA-Z\-_]+)(,relative)?;)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -28,8 +28,12 @@ contexts:
     - match: '(?:dns\.query|http\.method|(?:http\.uri(?!\.raw)|http\.uri\.raw)|http\.cookie|http\.user_agent|http\.accept(?!_(?:enc|lang))|http\.accept_enc|http\.accept_lang|http\.connection|http\.content_len|http\.content_type|http\.referer|http\.start|http\.header_names|http\.request_body|http\.stat_code|http\.stat_msg|http\.response_line|http\.response_body|http\.server|http\.location|http\.host(?!\.raw)|http\.host\.raw|file[\._]data)(?!;)'
       scope: rule.error.suricata
 
-    # Error - Missing semi-colon on no option Payload keywords
+    # Error - Missing semi-colon on no option payload keywords
     - match: '(?:nocase|startswith|endswith|fast_pattern)(?!;)'
+      scope: rule.error.suricata
+
+    # Error - Missing semi-colon on transformations
+    - match: '\b(?:dotprefix|strip_whitespace|compress_whitespace|to_(md5|sha1|sha256)|pcrexform|url_decode|xor)(?!;)\b'
       scope: rule.error.suricata
 
     # Error - Double Sticky Buffer

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -56,6 +56,11 @@ contexts:
     - match: '\bisdataat(?!:!?(?:[0-9]+|[a-zA-Z\-_]+)(,relative)?;)'
       scope: rule.error.suricata
 
+    # Error - Missing options or semi-colon payload keywords that accept option
+    # This also catches unrequired spaces
+    - match: '\bdns.opcode(?!:!?[0-9]+;)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -29,7 +29,7 @@ contexts:
       scope: rule.error.suricata
 
     # Error - Missing semi-colon on no option payload keywords
-    - match: '(?:nocase|startswith|endswith|fast_pattern)(?!;)'
+    - match: '(?:nocase|startswith|endswith|fast_pattern(?:only|:[0-9]+,[0-9]+)?)(?!;)'
       scope: rule.error.suricata
 
     # Error - Missing semi-colon on transformations

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -28,6 +28,10 @@ contexts:
     - match: '(?:dns\.query|http\.method|(?:http\.uri(?!\.raw)|http\.uri\.raw)|http\.cookie|http\.user_agent|http\.accept(?!_(?:enc|lang))|http\.accept_enc|http\.accept_lang|http\.connection|http\.content_len|http\.content_type|http\.referer|http\.start|http\.header_names|http\.request_body|http\.stat_code|http\.stat_msg|http\.response_line|http\.response_body|http\.server|http\.location|http\.host(?!\.raw)|http\.host\.raw|file[\._]data)(?!;)'
       scope: rule.error.suricata
 
+    # Error - Missing semi-colon on no option Payload keywords
+    - match: '(?:nocase|startswith|endswith|fast_pattern)(?!;)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -24,6 +24,10 @@ contexts:
     - match: 'content:\"[^\"]+\"(?!;)'
       scope: rule.error.suricata
 
+    # Error - Missing semi-colon at end of buffer
+    - match: '(?:dns\.query|http\.method|(?:http\.uri(?!\.raw)|http\.uri\.raw)|http\.cookie|http\.user_agent|http\.accept(?!_(?:enc|lang))|http\.accept_enc|http\.accept_lang|http\.connection|http\.content_len|http\.content_type|http\.referer|http\.start|http\.header_names|http\.request_body|http\.stat_code|http\.stat_msg|http\.response_line|http\.response_body|http\.server|http\.location|http\.host(?!\.raw)|http\.host\.raw|file[\._]data)(?!;)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata

--- a/Suricata/Suricata.sublime-syntax
+++ b/Suricata/Suricata.sublime-syntax
@@ -42,6 +42,13 @@ contexts:
     - match: '\b(depth|offset|distance|within)(?!:!?([0-9]+|[a-zA-Z\-_]+);)'
       scope: rule.error.suricata
 
+    # Error - Missing options on bsize/dsize payload keywords
+    # Support [a-zA-Z0-9\-_] for byte_extract variable names
+    # Support for ranges ie 100<>250
+    # This also catches unrequired spaces
+    - match: '\b[bd]size(?!:!?(?:[0-9]+|[a-zA-Z0-9\-_]+)?(?:<|>|[<>]=|<>)?(?:[0-9]+|[a-zA-Z0-9\-_]+);)'
+      scope: rule.error.suricata
+
     # Error - Double Sticky Buffer
     - match: '(dns\.query;\s*dns\.query;|dns\.opcode;\s*dns\.opcode;|http\.method\s*http\.method;|http\.uri;\s*http\.uri;|http\.uri\.raw;\s*http\.uri\.raw;|http\.cookie;\s*http\.cookie;|http\.user_agent;\s*http\.user_agent;|http\.accept;\s*http\.accept;|http\.accept_enc;\s*http\.accept_enc;|http\.accept_lang;\s*http\.accept_lang;|http\.connection;\s*http\.connection;|http\.content_len;\s*http\.content_len|http\.content_type;\s*http\.content_type|http\.referer;\s*http\.referer;|http\.start;\s*http\.start;|http\.header_names;\s*http\.header_names;|http\.request_body;\s*http\.request_body;|http\.stat_code;\s*http\.stat_code;|http\.stat_msg;\s*http\.stat_msg;|http\.response_line;\s*http\.response_line|http\.response_body;\s*http\.response_body;|http\.server;\s*http\.server;|http\.location;\s*http\.location|http\.host;\s*http\.host;|http\.host\.raw;\s*http\.host\.raw;|file[\._]data;\s*file[\._]data;)'
       scope: rule.error.suricata


### PR DESCRIPTION
Adds validation for ET Style Guide on items like non-required spaces, missing semi-colons, etc. 

## TODO 
Resolve FNs where keywords occur within content or msg matches. 
    This occurs with xor transform most often, but some http sticky buffers also occur within msg field.